### PR TITLE
fixes travis config node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 4
-  - 5
+  - "4"
+  - "5"
 
 branches:
   only:


### PR DESCRIPTION
I mean, maybe. Just checking to see if quotes make a difference.
Going from the logs, Travis seems to be using node `0.10.33` right
now.